### PR TITLE
REVIEW-ONLY: Deleting should actually delete

### DIFF
--- a/app/com/example/api/daos/DAOConventions.scala
+++ b/app/com/example/api/daos/DAOConventions.scala
@@ -43,8 +43,8 @@ trait DAOConventions[T<:{ def id: UUID }] { // scalastyle:ignore structural.type
   }
 
   def destroyById(id: UUID): Future[Int] = {
-    val query = table.filter(_.id === id).map(_.deleted).update(true)
-    db.run(query)
+    val query = table.filter(_.id === id)
+    db.run(query.delete)
   }
 
 }


### PR DESCRIPTION
So just putting this here to start a conversation, seeing as how the `DAOConventions` implements stuff, it looks like we never actually delete something, just sets a `deleted` column, and then uses that in other places. Is that something that we really like here at TicketFly. 

My concern is that if you use a table set up like this and run a custom query, like a join or something not supported by `DAOConventions`, then you have the possibility to miss the `deleted === false` command in the filter. Then your query could return back deleted things, which would be bad.

Whatcha guys think?
